### PR TITLE
When updating new weight, does not update the current weight

### DIFF
--- a/public/javascripts/ui/bin-info.js
+++ b/public/javascripts/ui/bin-info.js
@@ -54,7 +54,7 @@ function displayBin(bin) {
     const html = `
     <p>Bin Id: ${bin.binId}</p>
     <p>Bin Type: ${bin.binType}</p>
-    <p>Last Bin Weight: ${bin.lastBinWeight}</p>
+    <p>Current Bin Weight: ${bin.lastBinWeight}</p>
     <p>Location: ${bin.location}</p>
     <p>Notes: ${bin.notes}</p>
     <p>Previous Weights</p>


### PR DESCRIPTION
Fixes #63. There is nothing to fix. The weight entered into weighBin.html becomes the lastBinWeight of the bin. A new WeightHistory object is created and added to the WeightHistory sheet. 